### PR TITLE
修复重复发布二进制文件的问题

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,4 @@ deploy:
   on:
     tags: true
     all_branches: true
+    go: tip


### PR DESCRIPTION
会尝试发布 git 1.5 及 git tip 两个版本的二进制文件，但是github不允许重名，所以会失败。